### PR TITLE
text-1.2.1.0 exports Binary instances

### DIFF
--- a/Data/Text/Binary.hs
+++ b/Data/Text/Binary.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.Text.Binary where
 
+#if !(MIN_VERSION_text(1,2,1))
 import Control.Applicative ((<$>))
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -16,3 +18,4 @@ instance Binary T.Text where
 instance Binary L.Text where
     put = put . L.encodeUtf8
     get = L.decodeUtf8 <$> get
+#endif


### PR DESCRIPTION
If this package is built with `text-1.2.1.0` or later, the `Binary` instances defined here will conflict with the ones in the `text` package itself. This pull request uses a CPP pragma to only define the orphan instances if using an old version of `text`.
