### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/text-binary.cabal
+++ b/text-binary.cabal
@@ -7,7 +7,7 @@ description:
     <https://hackage.haskell.org/package/text>.
 license:            BSD2
 license-file:       LICENSE
-cabal-version:      >= 1.6
+cabal-version:      >= 1.8
 author:             Jakub Waszczuk
 maintainer:         waszczuk.kuba@gmail.com
 stability:          provisional


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: text-binary.cabal:22:21: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```